### PR TITLE
Allow widgets with a name-spaced `uiType`

### DIFF
--- a/src/jquery_ui_ember.js
+++ b/src/jquery_ui_ember.js
@@ -17,7 +17,16 @@ JQ.Widget = Em.Mixin.create({
 
     // Create a new instance of the jQuery UI widget based on its `uiType`
     // and the current element.
-    var ui = jQuery.ui[this.get('uiType')](options, this.get('element'));
+    var namespace = 'ui';
+    var uiType = this.get('uiType');
+
+    if (uiType.indexOf('.') >= 0) {
+      var parts = uiType.split('.');
+      namespace = parts[0];
+      uiType = parts[1];
+    }
+
+    var ui = jQuery[namespace][uiType](options, this.get('element'));
 
     // Save off the instance of the jQuery UI widget as the `ui` property
     // on this Ember view.


### PR DESCRIPTION
Defaults to widgets in the `ui` namespace to keep backwards compatibility. e.g. `uiType: 'droppable'` will still work.

Allow a widget with namespace to function e.g. [blueimp.fileupload](https://github.com/blueimp/jQuery-File-Upload) will work via `uiType: 'blueimp.fileupload'`.
